### PR TITLE
Update logo image path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 <br />
 <div align="center">
   <a href="https://github.com/tonkatommy/MRHQ-L5-Mission-0">
-    <img src="images/logo.png" alt="Logo" width="80" height="80">
+    <img src="./frontend/public/images/logo.png" alt="Logo" width="80" height="80">
   </a>
 
 <h3 align="center">Mission 0</h3>


### PR DESCRIPTION
Changed the logo image source path to point to './frontend/public/images/logo.png' for correct rendering in the README.